### PR TITLE
fix: add prefix 'Text/' to get in spine object

### DIFF
--- a/src/rendition.js
+++ b/src/rendition.js
@@ -327,7 +327,7 @@ class Rendition {
 			target = this.book.locations.cfiFromPercentage(parseFloat(target));
 		}
 
-		section = this.book.spine.get(target);
+		section = this.book.spine.get(target) || this.book.spine.get('Text/' + target);
 
 		if(!section){
 			displaying.reject(new Error("No Section Found"));


### PR DESCRIPTION
Se agrega el prefijo “Text/“ para la búsqueda de id de capítulos a través del spineByHref. 

  La razón principal de este problema es que los libros no respetan una estructura estándar. La librería busca el id interno del capitulo en el objeto spine a través de otro objeto llamado: “spineByHref”, este tiene como clave el nombre del capitulo y cómo valor su ID. Esté id es el que se obtiene para después en ir al objeto spineByItem y obtener toda la info del capitulo como por ejemplo su url de descarga.   
  
  Algunos libros le agregan el prefijo “Text/“ al nombre del capitulo y por ende a las keys del objeto “spineByHref” y por lo tanto se produce una excepción: “No Section Found” al intentar buscar el index del capitulo en este objeto