### PR TITLE
Se agrega prefijo 'text' en busca de los capitulos.

### DIFF
--- a/src/rendition.js
+++ b/src/rendition.js
@@ -327,7 +327,7 @@ class Rendition {
 			target = this.book.locations.cfiFromPercentage(parseFloat(target));
 		}
 
-		section = this.book.spine.get(target) || this.book.spine.get('Text/' + target);
+		section = this.book.spine.get(target) || this.book.spine.get('Text/' + target) || this.book.spine.get('text/' + target);
 
 		if(!section){
 			displaying.reject(new Error("No Section Found"));


### PR DESCRIPTION
Los epubs no respetan un estándar fijo de nombres de capitulos. Se agrega una condición cuando se busca el cap que añade un prefijo para los ebooks que interponen la palabra 'text'.