### PR TITLE
Replace juanamanso URL by conectarigualdad domain

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,5 +2,5 @@ export const arrUrls = [
   "https://95bfcd06vh.execute-api.us-west-2.amazonaws.com/prod/v1/books/", 
   'https://lcymlsspia.execute-api.us-east-1.amazonaws.com/dev/pdf/',
   'https://yu20kqqsg8.execute-api.us-east-1.amazonaws.com/production/pdf/',
-  'https://execute-api.juanamanso.edu.ar/prod/v1/books/'
+  'https://execute-api.conectarigualdad.edu.ar/prod/v1/books/'
 ];


### PR DESCRIPTION
The customer Educ.ar is requesting to switch from juanamanso.edu.ar to conectarigualdad.edu.ar domain; therefore we need to update the allowed entries in the URL array in order to make the new domain work as expected when using the reader